### PR TITLE
Dockerfile (web) changed to SLIM version

### DIFF
--- a/weight/Dockerfile
+++ b/weight/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:latest
+FROM python:3.7.2-slim
 
 COPY . /app
 


### PR DESCRIPTION
FROM python:3.7.2-slim